### PR TITLE
Append trailingSlash if not present on path param

### DIFF
--- a/src/plugins/file.ts
+++ b/src/plugins/file.ts
@@ -50,7 +50,11 @@ export class File {
     if ((/^\//.test(dir))) {
       rejectFn('directory cannot start with \/');
     }
-
+    
+    if (!(/\/$/.test(noSlash))) {
+      path += "/";
+    }
+    
     try {
       var directory = path + dir;
 
@@ -351,6 +355,10 @@ export class File {
       rejectFn('file cannot start with \/');
     }
 
+    if (!(/\/$/.test(noSlash))) {
+      path += "/";
+    }
+    
     try {
       var directory = path + file;
 


### PR DESCRIPTION
In some cases the incoming `path` variable may not necessarily contain a trailing slash, but in cases where the directory path is manually built within the plugin this was not protected against. This shouldn't be a big issue if consumers are using `cordova.file.*` for the path params, but not all consumers may be using this.
